### PR TITLE
Docs: Migrated file links from Proton Drive to Google Drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ This repository releases the official code, checkpoints, and data for our paper 
 
 ### Checkpoints
 
-The checkpoints for CoN-CLIP are given in the table below. Note that these are Proton Drive links. We are working on hosting somewhere that is more accessible via command-line.
+The Google Drive links to checkpoints for CoN-CLIP are given in the table below. 
 
 Model name        | CLIP Backbone | Checkpoint
 ----------------- | ------------- | ----------
-CoN-CLIP ViT-B/32 | ViT-B/32      | <a href="https://drive.proton.me/urls/H1034F41YM#M6nFERwJE8kL">Link</a>
-CoN-CLIP ViT-B/16 | ViT-B/16      | <a href="https://drive.proton.me/urls/G0N6PJWRDW#ZES92x7FPE4J">Link</a>
-CoN-CLIP ViT-L/14 | ViT-L/14      | <a href="https://drive.proton.me/urls/MXKZY486XG#YehnofGcLxR7">Link</a>
+CoN-CLIP ViT-B/32 | ViT-B/32      | <a href="https://drive.google.com/file/d/1st_HycYyHxUklCaLrllA-SK7QV5CYGVD/view">Link</a>
+CoN-CLIP ViT-B/16 | ViT-B/16      | <a href="https://drive.google.com/file/d/1OzePWGyEc_vElTeshUCIqJe0P8sQqyMR/view">Link</a>
+CoN-CLIP ViT-L/14 | ViT-L/14      | <a href="https://drive.google.com/file/d/10bF8l5G34mDIQuso8iBaRSvYATGe19n4/view">Link</a>
 
 
 ### Loading and Using CoN-CLIP

--- a/ccneg_dataset/README.md
+++ b/ccneg_dataset/README.md
@@ -2,7 +2,7 @@
 
 ## CC-Neg: Images
 
-The images for CC-Neg come from the ImageLabels split of the CC-3M which we prepare and provide <a href="https://drive.proton.me/urls/CPD0RPRVA4#lDBGak33rXEn">here</a>. Please find a compressed file called `ccneg_images.zip` in this directory, download, and extract the images. Verify that the structure of the `ccneg_images` folder becomes
+The images for CC-Neg come from the ImageLabels split of the CC-3M which we prepare and provide <a href="https://drive.google.com/file/d/1s3YQ_fkZqxp-sIW197SHqrgic9O0zQWR/view">here</a>. Please find a compressed file called `ccneg_images.zip` in this directory, download, and extract the images. Verify that the structure of the `ccneg_images` folder becomes
 
 ```plaintext
 ccneg_images
@@ -15,7 +15,7 @@ ccneg_images
 
 ## CC-Neg: Annotations
 
-The annotations containing the true caption and the negated (false) caption for each image in CC-Neg can be downloaded from <a href="https://drive.proton.me/urls/GC34W9VACG#xitsiMVh4HUU">here</a>. This file, named `ccneg_preprocessed.pt` must be downloaded into this directory. The helper for using distractor images during fine-tuning is provided <a href="https://drive.proton.me/urls/JAC3FBXP58#Yi2bmdl0xodv">here</a>, named `distractor_image_mapping.pt`.
+The annotations containing the true caption and the negated (false) caption for each image in CC-Neg can be downloaded from <a href="https://drive.google.com/file/d/1q5LThkN-7w2MduWU-tdK7On_sC9Mnu5Q/view?usp=drive_link">here</a>. This file, named `ccneg_preprocessed.pt` must be downloaded into this directory. The helper for using distractor images during fine-tuning is provided <a href="https://drive.google.com/file/d/1qNYKPclWkYjlL5IxjC6rKRgW_8QGs0BZ/view">here</a>, named `distractor_image_mapping.pt`.
 
 ## Paths for Data Configs
 


### PR DESCRIPTION
Replaced all Proton Drive links to Google Drive for accessibility and ease of use.